### PR TITLE
Adjust User-API SLI retrieve

### DIFF
--- a/thoth/slo_reporter/sli_workflow_latency.py
+++ b/thoth/slo_reporter/sli_workflow_latency.py
@@ -71,9 +71,8 @@ class SLIWorkflowLatency(SLIBase):
 
         return {
             f"{service}_workflows_latency": {
-                "query": f"avg(\
-                    argo_workflow_completion_time{query_labels_workflows} \
-                        - argo_workflow_start_time{query_labels_workflows})",
+                "query": f"avg(argo_workflow_completion_time{query_labels_workflows}"
+                f"- argo_workflow_start_time{query_labels_workflows})",
                 "requires_range": True,
                 "type": "average",
             },

--- a/thoth/slo_reporter/utils.py
+++ b/thoth/slo_reporter/utils.py
@@ -69,6 +69,7 @@ def manipulate_retrieved_metrics_vector(metrics_vector: List[float], action: str
 
     return metric
 
+
 def _evaluate_ascending_results(metrics_vector: List[float]) -> List[float]:
     """Evaluate vector with only ascending values."""
     counter = 0
@@ -89,6 +90,7 @@ def _evaluate_ascending_results(metrics_vector: List[float]) -> List[float]:
         counter += 1
 
     return modified_vector
+
 
 def connect_to_ceph(ceph_bucket_prefix: str, environment: str, bucket: Optional[str] = None) -> CephStore:
     """Connect to Ceph to store SLI metrics for Thoth."""


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

User-API metrics SLI where showing too low results for successfull requests.
http://superset-dh-prod-superset.cloud.datahub.psi.redhat.com/superset/dashboard/8/

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Introduce more robust way to evaluate user-API successful percentage requests.

Already run slo-reporter for the past 30 days to correct metrics.
