### PR TITLE
Fix key for changes since last week

### DIFF
--- a/thoth/slo_reporter/sli_thoth_integrations/sli_thoth_integration_users.py
+++ b/thoth/slo_reporter/sli_thoth_integrations/sli_thoth_integration_users.py
@@ -99,7 +99,7 @@ class SLIThothIntegrationsUsers(SLIBase):
                 html_inputs[name]["total_users"] = "N/A"
 
             if not last_week_data.empty and thoth_integration_counts_total != "ErrorMetricRetrieval":
-                old_value = last_week_data[last_week_data['integration'] == name]['total'].values[0]
+                old_value = last_week_data[last_week_data['integration'] == name]['total_users'].values[0]
                 change = evaluate_change(old_value=old_value, new_value=thoth_integration_counts_total)
 
                 html_inputs[name]["new"] = change


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
thoth_integrations_users/thoth_integrations_users-2021-03-12.csv
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.8/site-packages/pandas/core/indexes/base.py", line 3080, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 70, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 101, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 4554, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 4562, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'total'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "app.py", line 419, in <module>
    main()
  File "app.py", line 409, in main
    run_slo_reporter(
  File "app.py", line 377, in run_slo_reporter
    email_message = generate_email(sli_values_map, sli_report=sli_report)
  File "app.py", line 241, in generate_email
    message += "\n" + report_method(metric_data)
  File "/opt/app-root/src/thoth/slo_reporter/sli_thoth_integrations/sli_thoth_integration_users.py", line 116, in _report_sli
    html_inputs = self._evaluate_sli(sli=sli)
  File "/opt/app-root/src/thoth/slo_reporter/sli_thoth_integrations/sli_thoth_integration_users.py", line 102, in _evaluate_sli
    old_value = last_week_data[last_week_data['integration'] == name]['total'].values[0]
  File "/opt/app-root/lib64/python3.8/site-packages/pandas/core/frame.py", line 3024, in __getitem__
    indexer = self.columns.get_loc(key)
  File "/opt/app-root/lib64/python3.8/site-packages/pandas/core/indexes/base.py", line 3082, in get_loc
    raise KeyError(key) from err
KeyError: 'total'
```
