### PR TITLE
Update owners, pre-commit, and default URLs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,42 +6,36 @@ repos:
       - id: add-trailing-comma
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.14
+    rev: v1.2.0
     hooks:
       - id: remove-tabs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
-      - id: trailing-whitespace
-      - id: check-merge-conflict
-      - id: end-of-file-fixer
-      - id: name-tests-test
       - id: check-added-large-files
+      - id: check-ast
       - id: check-byte-order-marker
       - id: check-case-conflict
       - id: check-docstring-first
       - id: check-json
+      - id: check-merge-conflict
       - id: check-symlinks
-      - id: detect-private-key
-      - id: check-ast
+      - id: check-toml
+      - id: check-yaml
       - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: name-tests-test
+      - id: trailing-whitespace
 
   - repo: https://github.com/pycqa/pydocstyle.git
     rev: 6.1.1
     hooks:
       - id: pydocstyle
 
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
-    hooks:
-      - id: check-toml
-      - id: check-yaml
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
-
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.961
     hooks:
       - id: mypy
         exclude: '^(docs|tasks|tests)|setup\.py'
@@ -58,7 +52,7 @@ repos:
       - id: black-nb
 
   - repo: https://gitlab.com/PyCQA/flake8
-    rev: "3.9.1"
+    rev: "3.9.2"
     hooks:
       - id: flake8
         additional_dependencies: ["pep8-naming"]

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -6,7 +6,7 @@ presubmits:
     context: aicoe-ci/prow/pre-commit
     spec:
       containers:
-        - image: quay.io/thoth-station/thoth-precommit-py38:v0.13.0
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.14.3
           command:
             - "pre-commit"
             - "run"
@@ -27,7 +27,7 @@ presubmits:
     context: aicoe-ci/prow/mypy
     spec:
       containers:
-        - image: quay.io/thoth-station/thoth-pytest-ubi8-py38:v0.13.0
+        - image: quay.io/thoth-station/thoth-pytest-ubi8-py38:v0.14.3
           command:
             - "/bin/run-mypy"
             - "."

--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - pacospace
+  - codificat
+  - harshad16
   - sesheta
 reviewers:
-  - fridex
   - harshad16
 
 labels:

--- a/thoth/slo_reporter/configuration.py
+++ b/thoth/slo_reporter/configuration.py
@@ -105,13 +105,13 @@ class Configuration:
         # Grafana
         self.grafana_reference_base_url = os.getenv(
             "GRAFANA_DASHBOARD_BASE_URL",
-            "https://grafana-route-opf-monitoring.apps.zero.massopen.cloud/",
+            "https://grafana.operate-first.cloud/",
         )
 
         # Superset
         self.superset_dashboard_url = os.getenv(
             "SUPERSET_DASHBOARD_URL",
-            "https://hue-opf-datacatalog.apps.zero.massopen.cloud/",
+            "https://superset.operate-first.cloud/",
         )
 
         # TODO: Adjust logic to evaluate metrics not to maintain list of components


### PR DESCRIPTION
## Related Issues and Dependencies

The default URL changes are related to #343.

## This introduces a breaking change

- No

## This Pull Request implements

A few simple updates:
- Change the default base URLs for Grafana and Superset to point to current Operate First hostnames
- `OWNERS`: add myself replacing @pacospace and remove @fridex as reviewer (many thanks both!)
- update pre-commit versions and remove redundant config

## Description

<!--- Describe your changes in detail -->

Note that the URL change does not fully fix #343, because the e.g. dashboard names are currently hard-coded (e.g. https://github.com/thoth-station/slo-reporter/blob/68e3fa2f7043fb5c1c33b52f18342bb730daccce/thoth/slo_reporter/sli_references.py#L48) and they don't exist (by that name) in the destination.